### PR TITLE
Building and pushing new docker images on tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Docker Build and Publish
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build-and-release:
+    name: Building and Publishing to Dockerhub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Get Tag Version
+        id: tag
+        run: "echo ::set-output name=version::${GITHUB_REF#refs/*/}"
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-mattermost2discord
+          # Key is named differently to avoid collision
+          key: ${{ runner.os }}-mattermost2discord-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-mattermost2discord
+
+      - name: Build and Push
+        uses: docker/build-push-action@v2
+        env:
+          DOCKERHUB_REPOSITORY: "clubcedille/mattermost2discord"
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.DOCKERHUB_REPOSITORY }}:latest
+            ${{ env.DOCKERHUB_REPOSITORY }}:${{ steps.tag.outputs.version }}
+          cache-from: type=local,src=/tmp/.buildx-cache-mattermost2discord
+          # mode=max is used to cache all the layers
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new-mattermost2discord
+
+      - name: Refresh Cache
+        run: |
+          rm -rf /tmp/.buildx-cache-mattermost2discord
+          mv /tmp/.buildx-cache-new-mattermost2discord /tmp/.buildx-cache-mattermost2discord


### PR DESCRIPTION
- Added a workflow that will build, cache, and push the Docker images to clubcedille/mattermost2discord
- I did not use Goreleaser in this case since we're only building and publishing Docker images
- This will close #9 
 
# Example of the tags used while testing locally with ACT
![image](https://user-images.githubusercontent.com/28627982/117031215-5be66b80-acce-11eb-8018-cf6cf8e9eb5f.png)
# Result of the ACT run locally
![image](https://user-images.githubusercontent.com/28627982/117031295-6dc80e80-acce-11eb-87be-f8d899ec4c52.png)
