### PR TITLE
Got rid of all timestamp entries 

### DIFF
--- a/api/bot.go
+++ b/api/bot.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"time"
-
 	"github.com/gin-gonic/gin"
 )
 
@@ -17,9 +15,8 @@ type Bot interface {
 }
 
 type Content struct {
-	User      string
-	Message   string
-	Timestamp time.Time
+	User    string
+	Message string
 }
 
 type Payload struct {
@@ -30,9 +27,8 @@ type Payload struct {
 type DiscordPayload struct{}
 
 type MattermostPayload struct {
-	Text      string    `json:"text"`
-	Username  string    `json:"user_name"`
-	UserID    string    `json:"user_id"`
-	Token     string    `json:"token"`
-	Timestamp time.Time `json:"timestamp"`
+	Text     string `json:"text"`
+	Username string `json:"user_name"`
+	UserID   string `json:"user_id"`
+	Token    string `json:"token"`
 }

--- a/api/discord_bot.go
+++ b/api/discord_bot.go
@@ -25,6 +25,8 @@ func CreateDiscordBot() *DiscordBot {
 func (bot *DiscordBot) SendMessage(context *gin.Context) {
 	payload := bot.GetPayload(context)
 	content := bot.GetContent(payload)
+
+	bot.Session.ChannelTyping(DiscordChannel)
 	logger := loggerInstance()
 
 	discordMessage := fmt.Sprintf("%s said: %s", content.User, content.Message)
@@ -64,10 +66,9 @@ func (*DiscordBot) GetPayload(context *gin.Context) Payload {
 func (*DiscordBot) GetContent(payload Payload) Content {
 	message := strings.TrimSpace(strings.Split(payload.MattermostPayload.Text, TriggerWordMattermost)[1])
 	user := payload.MattermostPayload.Username
-	timestamp := payload.MattermostPayload.Timestamp
 	return Content{
-		User:      user,
-		Message:   message,
-		Timestamp: timestamp,
+		User:    user,
+		Message: message,
 	}
+
 }

--- a/api/discord_bot_test.go
+++ b/api/discord_bot_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -28,11 +27,10 @@ func (suite *DiscordTestSuite) SetupTest() {
 	suite.TriggerWordMattermost = "2disc"
 	suite.bot = &DiscordBot{}
 	suite.testPayload = MattermostPayload{
-		Text:      "2disc test",
-		Username:  "test",
-		UserID:    "test",
-		Token:     "test",
-		Timestamp: clockwork.NewFakeClock().Now(),
+		Text:     "2disc test",
+		Username: "test",
+		UserID:   "test",
+		Token:    "test",
 	}
 
 	DiscordToken = suite.DiscordToken


### PR DESCRIPTION
- Corrige le problème de ''invalid memory address''. J'ai décidé d'abandonner la variable timestamp qui semble être inutile après tout, car il n'y aura pas assez de circulation de message pour qu'une verification du timestamp de chaques messages soit nécessaire. Unless quelqu'un tient à cette information je nous en débarrasse.